### PR TITLE
Fix file size validation for video uploads

### DIFF
--- a/platform/backend/app/api/videos.py
+++ b/platform/backend/app/api/videos.py
@@ -29,12 +29,16 @@ async def upload_video(
             detail="Only video files are allowed"
         )
     
-    if file.size and file.size > settings.max_file_size:
+    # Read the entire file to enforce upload size limits since
+    # UploadFile doesn't expose a reliable ``size`` attribute.
+    contents = await file.read()
+    if len(contents) > settings.max_file_size:
         raise HTTPException(
             status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
-            detail=f"File size exceeds maximum allowed size of {settings.max_file_size} bytes"
+            detail=f"File size exceeds maximum allowed size of {settings.max_file_size} bytes",
         )
-    
+    file.file.seek(0)
+
     video_service = VideoService(db)
     video = await video_service.save_uploaded_file(file)
     


### PR DESCRIPTION
## Summary
- handle video file size validation by reading content and resetting pointer
- avoid AttributeError from using nonexistent `UploadFile.size`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*


------
https://chatgpt.com/codex/tasks/task_e_6897effee4948332b13b2afb43cd9ac0