### PR TITLE
docs: fix task diagram spelling

### DIFF
--- a/docs/project_status/project_plan.md
+++ b/docs/project_status/project_plan.md
@@ -28,7 +28,7 @@ The application will follow a microservices-oriented architecture, with a clear 
 graph TD
     A[User/Client] -->|API Requests| B(FastAPI Backend)
     B -->|Orchestrates| C(Celery Task Queue)
-    C -->|Sends/Recieves Tasks| D(Redis)
+    C -->|Sends/Receives Tasks| D(Redis)
     B -->|Stores/Retrieves Metadata| E(PostgreSQL Database)
     C -->|Executes Training| F(ML Modules: CV, NLP, Audio)
     F -->|Stores Trained Models| G(Model Storage)


### PR DESCRIPTION
## Summary
- correct 'Sends/Receives Tasks' spelling in project plan mermaid diagram

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'requests')*
- `pip install requests` *(fails: Could not connect to proxy: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6897f2ac693c83328e22e7e58314d974