### PR TITLE
Check upload file size before saving

### DIFF
--- a/platform/backend/app/api/videos.py
+++ b/platform/backend/app/api/videos.py
@@ -31,8 +31,8 @@ async def upload_video(
     
     # Read the entire file to enforce upload size limits since
     # UploadFile doesn't expose a reliable ``size`` attribute.
-    contents = await file.read()
-    if len(contents) > settings.max_file_size:
+    content = await file.read()
+    if len(content) > settings.max_file_size:
         raise HTTPException(
             status_code=status.HTTP_413_REQUEST_ENTITY_TOO_LARGE,
             detail=f"File size exceeds maximum allowed size of {settings.max_file_size} bytes",


### PR DESCRIPTION
## Summary
- enforce `settings.max_file_size` by reading upload content before saving video

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'requests')*


------
https://chatgpt.com/codex/tasks/task_e_6897f2ae8d4883328d9ca16bd483bb13