### PR TITLE
Clarify frame range query for detections endpoint

### DIFF
--- a/platform/backend/app/api/videos.py
+++ b/platform/backend/app/api/videos.py
@@ -121,7 +121,14 @@ async def get_video_detections(
     frame_end: Optional[int] = None,
     db: Session = Depends(get_db)
 ):
-    """Get detection results for a video"""
+    """Get detection results for a video.
+
+    The optional ``frame_start`` and ``frame_end`` query parameters can be
+    used to limit the returned detections to a specific inclusive range of
+    frame numbers. Only detections with ``frame_number`` greater than or
+    equal to ``frame_start`` and less than or equal to ``frame_end`` are
+    included in the response.
+    """
     
     video_service = VideoService(db)
     detections = video_service.get_detections(


### PR DESCRIPTION
## Summary
- document `frame_start` and `frame_end` query params for video detections endpoint

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'requests')*
- `pip install requests` *(fails: Could not find a version that satisfies the requirement requests; Could not connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6897f2b0746c83328af0ed1d43f8c46f